### PR TITLE
CASMCMS-7960 - update to newest alpine base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #
 # Dockerfile for csm-ssh-keys
 
-FROM artifactory.algol60.net/docker.io/alpine:3.13 as service
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as service
 WORKDIR /app
 RUN apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
@@ -35,7 +35,7 @@ COPY /src/ /app/src
 COPY /src/csmsshkeys /app/src/csmsshkeys
 COPY setup.py README.md .version gitInfo.txt /app/
 RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+    pip3 install --no-cache-dir --ignore-installed six -r requirements.txt && \
     pip3 install --no-cache-dir . && \
     rm -rf /app/*
 USER nobody:nobody

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -89,7 +89,7 @@ pipeline {
         stage("Build SP2 rpms") {
             agent {
                 docker {
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
+                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
                     reuseNode true
                     // Support docker in docker for clamav scan
                     args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
@@ -110,7 +110,7 @@ pipeline {
         stage("Build SP3 rpms") {
             agent {
                 docker {
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
+                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
                     reuseNode true
                     // Support docker in docker for clamav scan
                     args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
---trusted-host arti.dev.cray.com
 --trusted-host artifactory.algol60.net
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 requests


### PR DESCRIPTION
## Summary and Scope

To help resolve future CVE issues, we are updating to the newest supported alpine base image.  This service does not depend on any particular version of alpine, so I just updated to the most recent.

## Issues and Related PRs
* Resolves [CASMCMS-7960](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7960)

## Testing
### Tested on:
  * `Wasp`

### Test description:

I installed the pipeline built version using loftsman, tested that the service is operating as expected, then rolled back to the previous version and tested again.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - there are none
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as the service does not depend on any particular feature of alpine, just a generic alpine base image.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

