### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,9 @@ RUN mkdir /app/src
 COPY /src/ /app/src
 COPY /src/csmsshkeys /app/src/csmsshkeys
 COPY setup.py README.md .version gitInfo.txt /app/
-RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip3 install --upgrade pip && \
+    pip3 install --no-cache-dir --ignore-installed six -r requirements.txt && \
     pip3 install --no-cache-dir . && \
     rm -rf /app/*
 USER nobody:nobody


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5443

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Build system

### Test description:

It built, didn't it?

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

