### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
+
 ## [1.5.3] - 2023-06-21
 ### Added
 - Support for SLES SP5

--- a/constraints.txt
+++ b/constraints.txt
@@ -9,7 +9,7 @@ oauthlib==3.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.1
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.25.1
 requests-oauthlib==1.3.0
 rsa==4.7


### PR DESCRIPTION
Builds in this repo are failing due to the problem documented in [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713). Moving to PyYAML 6.0.1 resolves the problem. This PR moves PyYAML from 5.4.1 to 6.0.1.

A similar change is being made to a number of CSM repositories that are similarly affected.