### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
+
 ## [1.4.3] - 2023-01-10
 ### Changed
 - Enabled building of unstable artifacts

--- a/constraints.txt
+++ b/constraints.txt
@@ -9,7 +9,7 @@ oauthlib==3.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.1
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.25.1
 requests-oauthlib==1.3.0
 rsa==4.7


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm-ssh-keys/pull/37 to allow support/1.4 branch to be buildable