### PR TITLE
CASMCMS-8722: Use update_external_versions to get latest patch version of cfs-trust-ssh Python module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Dependencies
+- Use `update_external_versions` to get latest patch version of `cfs-ssh-trust` Python module.
+
 ## [1.5.4] - 2023-07-18
 ### Dependencies
 - Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,6 @@
 cachetools==4.2.1
 certifi==2020.12.5
-cfs-ssh-trust==1.3.79
+cfs-ssh-trust==0.0.0-cfssshtrust
 chardet==4.0.0
 google-auth==1.24.0
 idna==2.10

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,0 +1,4 @@
+image: cfs-ssh-trust
+    source: python
+    major: 1
+    minor: 6

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -31,3 +31,7 @@ sourcefile-novalidate: .stable
 tag: S-T-A-B-L-E
 targetfile: kubernetes/csmsshkeys/Chart.yaml
 targetfile: kubernetes/csmsshkeys/values.yaml
+
+sourcefile: cfs-ssh-trust.version
+tag: 0.0.0-cfssshtrust
+targetfile: constraints.txt


### PR DESCRIPTION
## Summary and Scope

`csm-ssh-keys` is using a pretty old version of the `cfs-trust-ssh` Python module (1.3.x, whereas 1.6.x is current). This PR modifies `csm-ssh-keys` to use `update_external_versions` to get the latest 1.6 patch version of this Python module.

