### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `tj-actions/changed-files` from 37 to 42 ([#46](https://github.com/Cray-HPE/csm-ssh-keys/pull/46), [#48](https://github.com/Cray-HPE/csm-ssh-keys/pull/48), [#50](https://github.com/Cray-HPE/csm-ssh-keys/pull/50), [#51](https://github.com/Cray-HPE/csm-ssh-keys/pull/51), [#53](https://github.com/Cray-HPE/csm-ssh-keys/pull/53))
 - Bump `actions/checkout` from 3 to 4 ([#47](https://github.com/Cray-HPE/csm-ssh-keys/pull/47))
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#49](https://github.com/Cray-HPE/csm-ssh-keys/pull/49))
+- Bump `kubernetes` from 12.0.1 to 22.6.0 to match CSM 1.6 Kubernetes version
 
 ## [1.5.6] - 2023-08-14
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,8 @@ cfs-ssh-trust==0.0.0-cfssshtrust
 chardet==4.0.0
 google-auth==1.24.0
 idna==2.10
-kubernetes==12.0.1
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 oauthlib==3.1.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.
