### PR TITLE
CAST-35972: Added regex to public key injection task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update key injection task with a regex to prevent deuplicate keys from getting added
 
 ## [1.7.1] - 2025-02-27
 ### Dependencies

--- a/ansible/roles/trust-csm-ssh-keys/tasks/main.yaml
+++ b/ansible/roles/trust-csm-ssh-keys/tasks/main.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -41,3 +41,4 @@
     state: present
     path: /root/.ssh/authorized_keys
     mode: '600'
+    regexp: "^{{ csm_public_key['response'] }}$"


### PR DESCRIPTION
## Summary and Scope
Adds a regex to the lineinfile task so that we don't add a duplicate line to the file every time this task is run

## Issues and Related PRs

* Resolves CAST-35972

## Testing

### Tested on:

  * Mug

### Test description:

Verified that repeated runs of this task no longer produce duplicate lines.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

